### PR TITLE
Enable autoloading of Helper class

### DIFF
--- a/src/HelperLocator.php
+++ b/src/HelperLocator.php
@@ -3,7 +3,7 @@ namespace Qiq;
 
 class HelperLocator
 {
-    static public function new(Escape $escape = null): self
+    static public function new(Escape $escape = null): static
     {
         $escape ??= new Escape('utf-8');
 

--- a/src/HelperLocator.php
+++ b/src/HelperLocator.php
@@ -3,68 +3,27 @@ namespace Qiq;
 
 class HelperLocator
 {
-    static public function new(Escape $escape = null) : self
+    static public function new(Escape $escape = null): self
     {
         $escape ??= new Escape('utf-8');
 
-        return new self([
-            'a'                     => function () use ($escape) { return new Helper\EscapeAttr($escape); },
-            'anchor'                => function () use ($escape) { return new Helper\Anchor($escape); },
-            'base'                  => function () use ($escape) { return new Helper\Base($escape); },
-            'button'                => function () use ($escape) { return new Helper\Button($escape); },
-            'c'                     => function () use ($escape) { return new Helper\EscapeCss($escape); },
-            'checkboxField'         => function () use ($escape) { return new Helper\CheckboxField($escape); },
-            'colorField'            => function () use ($escape) { return new Helper\ColorField($escape); },
-            'dateField'             => function () use ($escape) { return new Helper\DateField($escape); },
-            'datetimeField'         => function () use ($escape) { return new Helper\DatetimeField($escape); },
-            'datetimeLocalField'    => function () use ($escape) { return new Helper\DatetimeLocalField($escape); },
-            'dl'                    => function () use ($escape) { return new Helper\Dl($escape); },
-            'emailField'            => function () use ($escape) { return new Helper\EmailField($escape); },
-            'escape'                => function () use ($escape) { return $escape; },
-            'fileField'             => function () use ($escape) { return new Helper\FileField($escape); },
-            'form'                  => function () use ($escape) { return new Helper\Form($escape); },
-            'h'                     => function () use ($escape) { return new Helper\EscapeHtml($escape); },
-            'hiddenField'           => function () use ($escape) { return new Helper\HiddenField($escape); },
-            'image'                 => function () use ($escape) { return new Helper\Image($escape); },
-            'imageButton'           => function () use ($escape) { return new Helper\ImageButton($escape); },
-            'inputField'            => function () use ($escape) { return new Helper\InputField($escape); },
-            'items'                 => function () use ($escape) { return new Helper\Items($escape); },
-            'j'                     => function () use ($escape) { return new Helper\EscapeJs($escape); },
-            'label'                 => function () use ($escape) { return new Helper\Label($escape); },
-            'link'                  => function () use ($escape) { return new Helper\Link($escape); },
-            'linkStylesheet'        => function () use ($escape) { return new Helper\LinkStylesheet($escape); },
-            'meta'                  => function () use ($escape) { return new Helper\Meta($escape); },
-            'metaHttp'              => function () use ($escape) { return new Helper\MetaHttp($escape); },
-            'metaName'              => function () use ($escape) { return new Helper\MetaName($escape); },
-            'monthField'            => function () use ($escape) { return new Helper\MonthField($escape); },
-            'numberField'           => function () use ($escape) { return new Helper\NumberField($escape); },
-            'ol'                    => function () use ($escape) { return new Helper\Ol($escape); },
-            'passwordField'         => function () use ($escape) { return new Helper\PasswordField($escape); },
-            'radioField'            => function () use ($escape) { return new Helper\RadioField($escape); },
-            'rangeField'            => function () use ($escape) { return new Helper\RangeField($escape); },
-            'resetButton'           => function () use ($escape) { return new Helper\ResetButton($escape); },
-            'script'                => function () use ($escape) { return new Helper\Script($escape); },
-            'searchField'           => function () use ($escape) { return new Helper\SearchField($escape); },
-            'select'                => function () use ($escape) { return new Helper\Select($escape); },
-            'submitButton'          => function () use ($escape) { return new Helper\SubmitButton($escape); },
-            'telField'              => function () use ($escape) { return new Helper\TelField($escape); },
-            'textarea'              => function () use ($escape) { return new Helper\Textarea($escape); },
-            'textField'             => function () use ($escape) { return new Helper\TextField($escape); },
-            'timeField'             => function () use ($escape) { return new Helper\TimeField($escape); },
-            'u'                     => function () use ($escape) { return new Helper\EscapeUrl($escape); },
-            'ul'                    => function () use ($escape) { return new Helper\Ul($escape); },
-            'urlField'              => function () use ($escape) { return new Helper\UrlField($escape); },
-            'weekField'             => function () use ($escape) { return new Helper\WeekField($escape); },
-        ]);
+        return new static([
+            'a'      => static fn () => new Helper\EscapeAttr($escape),
+            'c'      => static fn () => new Helper\EscapeCss($escape),
+            'escape' => static fn () => $escape,
+            'h'      => static fn () => new Helper\EscapeHtml($escape),
+            'u'      => static fn () => new Helper\EscapeUrl($escape),
+        ], $escape);
     }
 
     protected array $factories = [];
-
     protected array $instances = [];
+    protected Escape $escape;
 
-    public function __construct(array $factories = [])
+    public function __construct(array $factories, ?Escape $escape = null)
     {
         $this->factories = $factories;
+        $this->escape  = $escape ?: new Escape('utf-8');
     }
 
     public function __call(string $name, array $args) : mixed
@@ -88,6 +47,16 @@ class HelperLocator
 
         if (function_exists($name)) {
             $this->instances[$name] = $func;
+
+            return true;
+        }
+
+        $mabeyHelper = 'Qiq\Helper\\' . $name;
+        if (class_exists($mabeyHelper)) {
+            if (! isset($this->factories[$name])) {
+                $this->factories[$name] = fn () => new $mabeyHelper($this->escape);
+            }
+
             return true;
         }
 

--- a/src/HelperLocator.php
+++ b/src/HelperLocator.php
@@ -51,10 +51,10 @@ class HelperLocator
             return true;
         }
 
-        $mabeyHelper = 'Qiq\Helper\\' . $name;
-        if (class_exists($mabeyHelper)) {
+        $maybeHelper = 'Qiq\Helper\\' . $name;
+        if (class_exists($maybeHelper)) {
             if (! isset($this->factories[$name])) {
-                $this->factories[$name] = fn () => new $mabeyHelper($this->escape);
+                $this->factories[$name] = fn () => new $maybeHelper($this->escape);
             }
 
             return true;


### PR DESCRIPTION
This PR will allow helper factories that are currently pre-registered all helper with the service locator to be registered with autoload on demand.

Users can use the helpers by simply creating their own helper files without touching any code for initialization.

This would be useful, for example, when using the same set of custom helpers in several applications.


```php
<?php
namespace Qiq\Helper;

class MyRot13 extends Helper
{
    public function __invoke(string $input) : string
    {
        // ...
       return $output;
    }
}
```

( We need to set the autoload in composer.json so that this class will be autoloaded properly in the user application.)