### PR TITLE
Add {{= ... ~}} syntax to consume trailing newline

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -209,6 +209,21 @@ with the opening tag. This Qiq code ...
 This is especially useful with looping output code, where you want to honor
 newlines at the very beginning and very end of the loop.
 
+Echoing Qiq can be made to consume a single trailing newline by using a tilde
+with the closing tag. This Qiq code ...
+
+```qiq
+{{h $foo ~}}
+```
+
+... compiles to this PHP code:
+
+```html+php
+<?= $this->h($foo) ?>
+```
+
+A tilde with the closing tag has no effect on non-echoing Quq code.
+
 ### Indenting
 
 Echoing Qiq tags will automatically set the current indent for helpers based on

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -222,7 +222,7 @@ with the closing tag. This Qiq code ...
 <?= $this->h($foo) ?>
 ```
 
-A tilde with the closing tag has no effect on non-echoing Quq code.
+A tilde with the closing tag has no effect on non-echoing Qiq code.
 
 ### Indenting
 

--- a/src/Compiler/QiqToken.php
+++ b/src/Compiler/QiqToken.php
@@ -41,7 +41,7 @@ class QiqToken
     public static function new(string $part) : ?self
     {
         $result = preg_match(
-            '/(\s*){{(\s*)([a-z=~]\s+|\s*)(\W|\w+)(.*?)(\s*)}}(\s*)/msi',
+            '/(\s*){{(\s*)([a-z=~]\s+|\s*)(\W|\w+)(.*?)(\s*)(~\s*)?}}(\s*)/msi',
             $part,
             $matches,
         );
@@ -57,7 +57,8 @@ class QiqToken
             firstWord: $matches[4] ?? '',
             remainder: $matches[5] ?? '',
             tailingSpaceInner: empty($matches[6]) ? ' ' : $matches[6],
-            tailingSpaceOuter: $matches[7] ?? '',
+            tailingSpaceOuter: $matches[8] ?? '',
+            tailingTagChar: empty($matches[7]) ? '' : trim($matches[7]),
         );
     }
 
@@ -71,6 +72,7 @@ class QiqToken
         protected string $remainder,
         protected string $tailingSpaceInner,
         protected string $tailingSpaceOuter,
+        protected string $tailingTagChar = '',
     ) {
         $this->fixEcho();
     }
@@ -193,6 +195,7 @@ class QiqToken
     {
         if (
             substr($this->tailingSpaceOuter, 0, strlen(PHP_EOL)) === PHP_EOL
+            && $this->tailingTagChar !== '~'
         ) {
             $this->closing .= '<?= PHP_EOL ?>';
         }

--- a/tests/Compiler/QiqTokenTest.php
+++ b/tests/Compiler/QiqTokenTest.php
@@ -174,4 +174,32 @@ class QiqTokenTest extends \PHPUnit\Framework\TestCase
         $php = PHP_EOL . '    <?php \Qiq\Indent::set("' . $set . '    ") ?><?= $this->textField(["name" => "street", "value" => $street]) ?>';
         $this->assertPhp($php, $qiq);
     }
+
+    public function testNewlineControl() : void
+    {
+        // echoing, honor trailing newline
+        $qiq = '{{= $noop }}' . PHP_EOL;
+        $php = '<?= $noop ?><?= PHP_EOL ?>' . PHP_EOL;
+        $this->assertPhp($php, $qiq);
+
+        // echoing, consume trailing newline
+        $qiq = '{{= $noop ~}}' . PHP_EOL;
+        $php = '<?= $noop ?>' . PHP_EOL;
+        $this->assertPhp($php, $qiq);
+
+        // non-echoing, consume trailing newline
+        $qiq = '{{ $noop }}' . PHP_EOL;
+        $php = '<?php $noop ?>' . PHP_EOL;
+        $this->assertPhp($php, $qiq);
+
+        // non-echoing, consume trailing newline
+        $qiq = '{{ $noop ~}}' . PHP_EOL;
+        $php = '<?php $noop ?>' . PHP_EOL;
+        $this->assertPhp($php, $qiq);
+
+        // non-echoing, add leading newline
+        $qiq = '{{~ $noop }}' . PHP_EOL;
+        $php = '<?= PHP_EOL ?><?php $noop ?>' . PHP_EOL;
+        $this->assertPhp($php, $qiq);
+    }
 }


### PR DESCRIPTION
@harikt @koriym and all: this PR adds new syntax for the **closing** tag, to allow echoing Qiq code to consume a newline immediately after the closing tag.

Normal PHP code does not output a trailing newline after a closing PHP tag. However, echoing Qiq code (`{{= ... }}`) *does* honor a trailing newline, by adding `<?= PHP_EOL ?>` when it sees a newline after the closing `}}` tag.

Lately, though, the blocks work in #16 has made me wish for a way to get back the normal PHP behavior in limited cases.

Thus, this PR: if you have echoing Qiq code, and use a tilde with the closing tag, the normal PHP behavior is restored, and no PHP_EOL is added.

You can see the tests for examples.

@koriym Please make your translation team aware of the documentation change.

Thoughts? Concerns?

Thanks everyone!
