### PR TITLE
Fix assignment

### DIFF
--- a/tests/CatalogTest.php
+++ b/tests/CatalogTest.php
@@ -170,7 +170,7 @@ class CatalogTest extends \PHPUnit\Framework\TestCase
         }
 
         // the count will change as number of templates changes
-        $this->assertCount(21, $actual);
+        $this->assertCount(22, $actual);
     }
 
     protected function assertOutput(string $expect, string $file) : void

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -7,6 +7,8 @@ use Qiq\Compiler\NonCompiler;
 use Qiq\Compiler\QiqCompiler;
 use RuntimeException;
 
+use function file_get_contents;
+
 class TemplateTest extends \PHPUnit\Framework\TestCase
 {
     protected HtmlTemplate $template;
@@ -160,5 +162,19 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
         $template = Template::new(cachePath: false);
         $actual = $template->getCatalog()->getCompiler();
         $this->assertInstanceOf(NonCompiler::class, $actual);
+    }
+
+    public function testAssignment() : void
+    {
+        $path = $this->template->getCatalog()->getCompiled('ext/assignment');
+        $actual = $this->template->getCatalog()->getCompiler()->compile($path);
+        $expect = <<<'EOT'
+<?php /** @var Qiq\Engine&Qiq\Helper\Html\HtmlHelpers $this */ ?>
+<?= $this->anchor ('https://qiqphp.com', 'Qiq Project') ?><?= PHP_EOL ?>
+<?php $a = $this->anchor ('https://qiqphp.com', 'Qiq Project') ?>
+
+EOT;
+
+        $this->assertSame($expect, file_get_contents($actual));
     }
 }

--- a/tests/templates/ext/assignment.php
+++ b/tests/templates/ext/assignment.php
@@ -1,0 +1,3 @@
+{{ /** @var Qiq\Engine&Qiq\Helper\Html\HtmlHelpers $this */ }}
+{{= anchor ('https://qiqphp.com', 'Qiq Project') }}
+{{ $a = anchor ('https://qiqphp.com', 'Qiq Project') }}


### PR DESCRIPTION
### Qiq template

```
{{ /** @var Qiq\Engine&Qiq\Helper\Html\HtmlHelpers $this */ }}
{{= anchor ('https://qiqphp.com', 'Qiq Project') }}
{{ $a = anchor ('https://qiqphp.com', 'Qiq Project') }}
```

### Compiled (now)

```
<?php /** @var Qiq\Engine&Qiq\Helper\Html\HtmlHelpers $this */ ?>
<?= $this->anchor ('https://qiqphp.com', 'Qiq Project') ?><?= PHP_EOL ?>
<?php $a = anchor ('https://qiqphp.com', 'Qiq Project') ?>
```

### Expectations

```
<?php /** @var Qiq\Engine&Qiq\Helper\Html\HtmlHelpers $this */ ?>
<?= $this->anchor ('https://qiqphp.com', 'Qiq Project') ?><?= PHP_EOL ?>
<?php $a = $this->anchor ('https://qiqphp.com', 'Qiq Project') ?>
```

👉 `$a = $this->anchor`