### PR TITLE
Add Psalm taint annotations for security analysis

### DIFF
--- a/src/Helper/Html/Escape.php
+++ b/src/Helper/Html/Escape.php
@@ -19,6 +19,8 @@ class Escape
 
     /**
      * @param null|scalar|\Stringable|array<null|scalar|\Stringable|array<null|scalar|\Stringable>> $raw
+     *
+     * @psalm-taint-escape html
      */
     public function a(mixed $raw) : string
     {
@@ -64,6 +66,8 @@ class Escape
 
     /**
      * @param null|scalar|\Stringable $raw
+     *
+     * @psalm-taint-escape css
      */
     public function c(mixed $raw) : string
     {
@@ -72,6 +76,8 @@ class Escape
 
     /**
      * @param null|scalar|\Stringable $raw
+     *
+     * @psalm-taint-escape html
      */
     public function h(mixed $raw) : string
     {
@@ -80,6 +86,8 @@ class Escape
 
     /**
      * @param null|scalar|\Stringable $raw
+     *
+     * @psalm-taint-escape html
      */
     public function j(mixed $raw) : string
     {
@@ -88,6 +96,8 @@ class Escape
 
     /**
      * @param null|scalar|\Stringable $raw
+     *
+     * @psalm-taint-escape html
      */
     public function u(mixed $raw) : string
     {


### PR DESCRIPTION
## Summary

Add `@psalm-taint-escape` annotations to Escape helper methods for Psalm's taint analysis.

## Changes

- `@psalm-taint-escape html` on:
  - `h()` - HTML escape
  - `a()` - HTML attribute escape  
  - `j()` - JavaScript escape (escapes for HTML context)
  - `u()` - URL escape
- `@psalm-taint-escape css` on:
  - `c()` - CSS escape

These annotations enable Psalm's taint analysis to track potentially dangerous user input through the escape functions, ensuring proper sanitization before output.

## Test Plan

- [ ] Existing tests pass
- [ ] Run `./vendor/bin/psalm --taint-analysis` to verify annotations work